### PR TITLE
Add in compatibility fixes for commander v7

### DIFF
--- a/xforge
+++ b/xforge
@@ -24,6 +24,8 @@ module.exports.xforge = async function(inprocessArgs) {
     args.option("-o, --other <args>", "other arguments, passed to the build files", (otherArgs, other) => {other.push(otherArgs); return other;}, []);
     if (inprocessArgs) {args = inprocessArgs; args.outputHelp =_=>CONSTANTS.LOGERROR("Bad arguments to XForge");} else args.parse(process.argv);
 
+    if (args._optionValues) args = { ...args, ...args._optionValues };
+
     if (args.colors) CONSTANTS.COLORED_OUT = true;
 
     if (args.other) CONSTANTS.OTHER_ARGS = args.other;


### PR DESCRIPTION
## Issue:
- XForge breaks with latest commander version
![image](https://user-images.githubusercontent.com/14257055/106570832-6c1a6d80-655c-11eb-9efa-13044dd141aa.png)

## Fixes:
- Make option values available inside the `args` object
  - This will fix issue with commander v7
  - Will also maintain backward compatibility with older versions
  - No major changes to code required

> Tested for JS Compiler
> Tested with commander v6.1.0
> Tested with commander v7.0.0
