### PR TITLE
Binary logging

### DIFF
--- a/conf/c_cpp_compiler.json
+++ b/conf/c_cpp_compiler.json
@@ -1,4 +1,4 @@
 {
     "dependency_generator": "gcc -E -MM -c",
-    "deepDependencyAnalysis": true
+    "deepDependencyAnalysis": false
 }

--- a/extensions/os_cmd.js
+++ b/extensions/os_cmd.js
@@ -16,22 +16,22 @@ exports.os_cmd = (cmd, stream = false) => {
     CONSTANTS.LOGINFO(`[REQUEST]: ${cmd}`);
 
     return new Promise((resolve, reject) => ticketing.getTicket(_=>{
-        let osProcess = exec(cmd, {maxBuffer: CONSTANTS.MAX_STDIO_BUFFER}, (error, data, stderr) => {
+        let osProcess = exec(cmd, {maxBuffer: CONSTANTS.MAX_STDIO_BUFFER, encoding : 'binary'}, (error, data, stderr) => {
             ticketing.releaseTicket();
             
             CONSTANTS.LOGEXEC(`[PID:${process.pid}] ${cmd}`);
 
-            if (data && !stream) CONSTANTS.LOGINFO(`[PID:${process.pid}] ${data}`);
-            if (stderr && error) CONSTANTS.LOGERROR(`[PID:${process.pid}] ${stderr}`);
-            else if (stderr && !stream) CONSTANTS.LOGWARN(`[PID:${process.pid}] ${stderr}`);
+            if (data && !stream) CONSTANTS.logInfo(process.pid, data);
+            if (stderr && error) CONSTANTS.logError(process.pid, stderr);
+            else if (stderr && !stream) CONSTANTS.logWarn(process.pid, stderr);
 
             if (error) reject(error);
             else resolve(data);
         });
 
         if (stream) {
-            osProcess.stdout.on("data", data => CONSTANTS.LOGINFO(`[PID:${process.pid}] ${data}`));
-            osProcess.stderr.on("data", data => CONSTANTS.LOGWARN(`[PID:${process.pid}] ${data}`));
+            osProcess.stdout.on("data", data => CONSTANTS.logInfo(process.pid, data));
+            osProcess.stderr.on("data", data => CONSTANTS.logWarn(process.pid, data));
         }
     }));
 }

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -27,6 +27,52 @@ exports.LOGHELP = s => console.info(getColoredMessage(`[HELP] ${s}\n`, colors.ma
 exports.LOGSUCCESS = _ => exports.LOGINFO("Success, done.");
 exports.LOGFAILURE = _ => exports.LOGERROR("Build failed.");
 
+exports.COLOR = { 
+    reset: '\x1b[0m',
+    bright: '\x1b[1m',
+    dim: '\x1b[2m',
+    underscore: '\x1b[4m',
+    blink: '\x1b[5m',
+    reverse: '\x1b[7m',
+    hidden: '\x1b[8m',
+  
+    fgBlack: '\x1b[30m',
+    fgRed: '\x1b[31m',
+    fgGreen: '\x1b[32m',
+    fgYellow: '\x1b[33m',
+    fgBlue: '\x1b[34m',
+    fgMagenta: '\x1b[35m',
+    fgCyan: '\x1b[36m',
+    fgWhite: '\x1b[37m',
+  
+    bgBlack: '\x1b[40m',
+    bgRed: '\x1b[41m',
+    bgGreen: '\x1b[42m',
+    bgYellow: '\x1b[43m',
+    bgBlue: '\x1b[44m',
+    bgMagenta: '\x1b[45m',
+    bgCyan: '\x1b[46m',
+    bgWhite: '\x1b[47m',
+};
+
+exports.logError =  (pid, msg) => {
+    process.stderr.write(`${CONSTANTS.COLOR.fgRed}[ERROR] [PID:${pid}] `);
+    process.stderr.write(msg, 'binary');
+    process.stderr.write(`${CONSTANTS.COLOR.reset}\n`);
+}
+
+exports.logWarn =  (pid, msg) => {
+    process.stderr.write(`${CONSTANTS.COLOR.fgYellow}[WARN] [PID:${pid}] `);
+    process.stderr.write(msg, 'binary');
+    process.stderr.write(`${CONSTANTS.COLOR.reset}\n`);
+}
+
+exports.logInfo =  (pid, msg) => {
+    process.stdout.write(`${CONSTANTS.COLOR.fgGreen}[INFO] [PID:${pid}] `);
+    process.stdout.write(msg, 'binary');
+    process.stderr.write(`${CONSTANTS.COLOR.reset}\n`);
+}
+
 exports.EXITOK = _ => exports.INPROCESSMODE?0:process.exit(0);
 exports.EXITFAILED = _ => exports.INPROCESSMODE?1:process.exit(1);
 


### PR DESCRIPTION
When using ja_JP.eucjp locale console.info, console.error and console.warn break the Japanese encoding. 

To avoid this, it is proposed to use not to use encoding-decoding, but to output messages from external programs as they are in binary form. When calling exec, it is suggested to use an additional option encoding: 'binary', and instead of using the console functions, use process.stdout.write and process.stderr.write

In addition to these changes, I propose to change the value of deepDependencyAnalysis in conf/c_cpp_compiler.json from true to false, since this is an extension of functionality and usually deep analysis of dependencies is not required.