### PR TITLE
install npm modules locally

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -1,5 +1,5 @@
 @echo off
-call npm install shelljs -g
-call npm install commander -g
-call npm install google-closure-compiler -g
-call npm install terser -g
+call npm install shelljs
+call npm install commander
+call npm install google-closure-compiler
+call npm install terser


### PR DESCRIPTION
When the npm modules are installed globally, try to build the Monkshu desktop application. xforge cannot find modules:
```>node ..\xforge\xforge -c -f build\buildApp.xf.js
node:internal/modules/cjs/loader:936
  throw err;
  ^

Error: Cannot find module 'commander'
```