### PR TITLE
[fix] js complier bundle creation failed for files having special characters

### DIFF
--- a/extensions/js_compiler.js
+++ b/extensions/js_compiler.js
@@ -27,6 +27,8 @@ exports.js_compile = async (source_file, output_file, useTerser=false) => {
 
     const outDir = path.dirname(output_file); 
     if (!await existsAsync(outDir)) mkdirAsync(outDir, {recursive:true});
-    const cmd = useTerser?`${COMPILER_CMD_TERSER} "${source_file}" -c -m -o "${output_file}"`:`${COMPILER_CMD_GOOGLE} "${source_file}" --js_output_file "${output_file}"`;
+    const cmd = useTerser?`${COMPILER_CMD_TERSER} "${_escapeSpecialChars(source_file)}" -c -m -o "${_escapeSpecialChars(output_file)}"`:`${COMPILER_CMD_GOOGLE} "${_escapeSpecialChars(source_file)}" --js_output_file "${_escapeSpecialChars(output_file)}"`;
     return os_cmd(cmd);
 }
+
+const _escapeSpecialChars = string => string.replace(/[+?^${}()|[\]\\*]/g, '\\$&');


### PR DESCRIPTION
Issue: Getting an error when trying to load files with special characters, for example, $$.js

Fix: added special character handling for filePath while calling the compiler in xforge/extension/js_complier.js